### PR TITLE
Added missing Object.getPropertyDescriptor arg

### DIFF
--- a/INITIALIZER_INTEROP.md
+++ b/INITIALIZER_INTEROP.md
@@ -54,7 +54,7 @@ class Person {
 
 class Person {
   constructor() {
-    let _born = Object.getPropertyDescriptor('born');
+    let _born = Object.getPropertyDescriptor(this, 'born');
     this.born = _born.initializer.call(this);
   }
 }
@@ -101,7 +101,7 @@ function readonly(target, name, desc) {
 
 class Person {
   constructor() {
-    let _born = Object.getPropertyDescriptor('born');
+    let _born = Object.getPropertyDescriptor(this, 'born');
     this.born = _born.initializer.call(this);
   }
 }


### PR DESCRIPTION
Signature should be `Object.getPropertyDescriptor(obj: Object, name: string): PropertyDescriptor`
http://wiki.ecmascript.org/doku.php?id=harmony:extended_object_api&s=object+getpropertydescriptor

Depending on how specific you want to be, it may be wise to de-sugar to `Object.getOwnPropertyDescriptor` instead though, directly on the prototype..IMO:

``` javascript
class Person {
  constructor() {
    let _born = Object.getOwnPropertyDescriptor(Object.getPrototypeOf(this), 'born');
    this.born = _born.initializer.call(this);
  }
}

Object.defineProperty(Person.prototype, 'born', {
  initializer() { return Date.now() },
  enumerable: true,
  writable: true,
  configurable: true
});
```

But AFAIK that's a side discussion since this is about decorators, not the initializers themselves..
