### PR TITLE
Execute decorators in their declaration order

### DIFF
--- a/README.md
+++ b/README.md
@@ -188,7 +188,7 @@ var Foo = (function () {
   class Foo {
   }
 
-  Foo = F("color")(Foo = G(Foo) || Foo) || Foo;
+  Foo = G(Foo = F("color")(Foo) || Foo) || Foo;
   return Foo;
 })();
 ```
@@ -200,7 +200,7 @@ var Foo = (function () {
   function Foo() {
   }
 
-  Foo = F("color")(Foo = G(Foo) || Foo) || Foo;
+  Foo = G(Foo = F("color")(Foo) || Foo) || Foo;
   return Foo;
 })();
 ```
@@ -226,8 +226,8 @@ var Foo = (function () {
   }
 
   var _temp;
-  _temp = F("color")(Foo.prototype, "bar",
-    _temp = G(Foo.prototype, "bar",
+  _temp = G(Foo.prototype, "bar",
+    _temp = F("color")(Foo.prototype, "bar",
       _temp = Object.getOwnPropertyDescriptor(Foo.prototype, "bar")) || _temp) || _temp;
   if (_temp) Object.defineProperty(Foo.prototype, "bar", _temp);
   return Foo;
@@ -243,8 +243,8 @@ var Foo = (function () {
   Foo.prototype.bar = function () { }
 
   var _temp;
-  _temp = F("color")(Foo.prototype, "bar",
-    _temp = G(Foo.prototype, "bar",
+  _temp = G(Foo.prototype, "bar",
+    _temp = F("color")(Foo.prototype, "bar",
       _temp = Object.getOwnPropertyDescriptor(Foo.prototype, "bar")) || _temp) || _temp;
   if (_temp) Object.defineProperty(Foo.prototype, "bar", _temp);
   return Foo;
@@ -274,8 +274,8 @@ var Foo = (function () {
   }
 
   var _temp;
-  _temp = F("color")(Foo.prototype, "bar",
-    _temp = G(Foo.prototype, "bar",
+  _temp = G(Foo.prototype, "bar",
+    _temp = F("color")(Foo.prototype, "bar",
       _temp = Object.getOwnPropertyDescriptor(Foo.prototype, "bar")) || _temp) || _temp;
   if (_temp) Object.defineProperty(Foo.prototype, "bar", _temp);
   return Foo;
@@ -295,8 +295,8 @@ var Foo = (function () {
   });
 
   var _temp;
-  _temp = F("color")(Foo.prototype, "bar",
-    _temp = G(Foo.prototype, "bar",
+  _temp = G(Foo.prototype, "bar",
+    _temp = F("color")(Foo.prototype, "bar",
       _temp = Object.getOwnPropertyDescriptor(Foo.prototype, "bar")) || _temp) || _temp;
   if (_temp) Object.defineProperty(Foo.prototype, "bar", _temp);
   return Foo;
@@ -324,8 +324,8 @@ var o = (function () {
   }
 
   var _temp;
-  _temp = F("color")(_obj, "bar",
-    _temp = G(_obj, "bar",
+  _temp = G(_obj, "bar",
+    _temp = F("color")(_obj, "bar",
       _temp = void 0) || _temp) || _temp;
   if (_temp) Object.defineProperty(_obj, "bar", _temp);
   return Foo;
@@ -341,8 +341,8 @@ var o = (function () {
     }
 
     var _temp;
-    _temp = F("color")(_obj, "bar",
-        _temp = G(_obj, "bar",
+    _temp = G(_obj, "bar",
+        _temp = F("color")(_obj, "bar",
             _temp = void 0) || _temp) || _temp;
     if (_temp) Object.defineProperty(_obj, "bar", _temp);
     return Foo;
@@ -372,8 +372,8 @@ var o = (function () {
   }
 
   var _temp;
-  _temp = F("color")(_obj, "bar",
-    _temp = G(_obj, "bar",
+  _temp = G(_obj, "bar",
+    _temp = F("color")(_obj, "bar",
       _temp = void 0) || _temp) || _temp;
   if (_temp) Object.defineProperty(_obj, "bar", _temp);
   return Foo;
@@ -393,8 +393,8 @@ var o = (function () {
   });
 
   var _temp;
-  _temp = F("color")(_obj, "bar",
-    _temp = G(_obj, "bar",
+  _temp = G(_obj, "bar",
+    _temp = F("color")(_obj, "bar",
       _temp = void 0) || _temp) || _temp;
   if (_temp) Object.defineProperty(_obj, "bar", _temp);
   return Foo;


### PR DESCRIPTION
Currently, if you write this:

``` js
@F("color")
@G
class Foo {
}
```

It gets desugared to this:

``` js
var Foo = (function () {
  class Foo {
  }

  Foo = F("color")(Foo = G(Foo) || Foo) || Foo;
  return Foo;
})();
```

Which executes `G()` before `F()`. I assume this is an error (or I don't see the point of this), so I rewrote all the desugared examples to execute `F()` before `G()`:

``` js
var Foo = (function () {
  class Foo {
  }

  Foo = G(Foo = F("color")(Foo) || Foo) || Foo;
  return Foo;
})();
```
