### PR TITLE
Switch from `@` `AssignmentExpression` to `@` `LeftHandSideExpression`

### DIFF
--- a/README.md
+++ b/README.md
@@ -407,7 +407,7 @@ var o = (function () {
 &emsp;&emsp;&emsp;*DecoratorList*<sub> [?Yield]opt</sub>&emsp; *Decorator*<sub> [?Yield]</sub>
 
 &emsp;&emsp;*Decorator*<sub> [Yield]</sub>&emsp;:  
-&emsp;&emsp;&emsp;`@`&emsp;*AssignmentExpression*<sub> [?Yield]</sub>
+&emsp;&emsp;&emsp;`@`&emsp;*LeftHandSideExpression*<sub> [?Yield]</sub>
 
 &emsp;&emsp;*PropertyDefinition*<sub> [Yield]</sub>&emsp;:  
 &emsp;&emsp;&emsp;*IdentifierReference*<sub> [?Yield]</sub>  


### PR DESCRIPTION
`AssignmentExpression` has unbounded lookahead problems when coupled with generator methods:

```
class Foo {
  @a * b() {}
}
```

Using LHSExpression circumvents this (at the expense of some [seemingly less-useful] expressions)
