### PR TITLE
Update README.md - missing noun in line 71

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ function defineDecoratedProperty(target, { initializer, enumerable, configurable
 }
 ```
 
-The has an opportunity to intercede before the relevant `defineProperty` actually occurs.
+The decorator has an opportunity to intercede before the relevant `defineProperty` actually occurs.
 
 A decorator that precedes syntactic getters and/or setters operates on an accessor description:
 


### PR DESCRIPTION
I have extrapolated that "The decorator" was meant in this line. Hopefully the interpretation is correct.
