### PR TITLE
Fix description parameter in nonenumerable

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ let description = {
   configurable: true
 }
 
-function nonenumerable(target, name, description) {
+function nonenumerable(target, name, descriptor) {
   descriptor.enumerable = false;
   return descriptor;
 }


### PR DESCRIPTION
I think there's an error in the nonenumerable example. I renamed the description parameter to be descriptor.
