### PR TITLE
Fix typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ function defineDecoratedProperty(target, { initializer, enumerable, configurable
 }
 ```
 
-The has an opportunity to intercede before the relevant `defineProperty` actually occurs.
+The engine then has an opportunity to intercede before the relevant `defineProperty` actually occurs.
 
 A decorator that precedes syntactic getters and/or setters operates on an accessor description:
 


### PR DESCRIPTION
This commit fixes an apparent typo. It seems to me that it is the _engine_ that is interceding, not the _decorator_, as suggested in other PRs.