### PR TITLE
Fix typo in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ let description = {
   configurable: true
 }
 
-function nonenumerable(target, name, description) {
+function nonenumerable(target, name, descriptor) {
   descriptor.enumerable = false;
   return descriptor;
 }


### PR DESCRIPTION
`description` should be `descriptor` in the arg list.