### PR TITLE
Typo in `nonenumerable` function example

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ let description = {
   configurable: true
 }
 
-function nonenumerable(target, name, description) {
+function nonenumerable(target, name, descriptor) {
   descriptor.enumerable = false;
   return descriptor;
 }


### PR DESCRIPTION
`descriptor` not defined in example scope - you meant `descriptor` as the input, right?  Or am I missing something?